### PR TITLE
Small change to make the display of temperature ranges clearer. 

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -556,7 +556,7 @@ WeatherMenuButton.prototype = {
                     comment = this.get_weather_condition(code);
 
                 forecastUi.Day.text = date_string[i] + ' (' + this.get_locale_day(forecastData.get_string_member('day')) + ')';
-                forecastUi.Temperature.text = t_low + '\u2013' + t_high + ' ' + this.unit_to_unicode();
+                forecastUi.Temperature.text = t_low + ' \u2013 ' + t_high + ' ' + this.unit_to_unicode();
                 forecastUi.Summary.text = comment;
                 forecastUi.Icon.icon_name = this.get_weather_icon_safely(code);
             }


### PR DESCRIPTION
This makes the readout clearer - especially when highest temperature is also negative! (As it has been in Europe recently in degrees C).

Edit: Actually I mean it's clearer when the low temperature is negative and the high temperature is positive, compare
old: '-4-1'
new: '-4 - 1'
