### PR TITLE
A modify changed the request url and the way to analyse the response data.

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -240,7 +240,7 @@ WeatherMenuButton.prototype = {
     },
 
     get_weather_url: function() {
-        return 'http://query.yahooapis.com/v1/public/yql?format=json&q=select link,location,wind,atmosphere,units,item.condition,item.forecast from weather.forecast where location="' + this._woeid + '" and u="' + this.unit_to_url() + '"';
+        return 'http://query.yahooapis.com/v1/public/yql?format=json&q=select link,location,wind,atmosphere,units,item.condition,item.forecast from weather.forecast where woeid="' + this._woeid + '" and u="' + this.unit_to_url() + '"';
     },
 
     get_weather_icon: function(code) {
@@ -495,11 +495,11 @@ WeatherMenuButton.prototype = {
 
     refreshWeather: function(recurse) {
         this.load_json_async(this.get_weather_url(), function(json) {
-
             try {
-            let weather = json.get_object_member('query').get_object_member('results').get_object_member('channel');
+            let weathers = json.get_object_member('query').get_object_member('results').get_array_member('channel').get_elements();
+            let weather = weathers[0].get_object();
             let weather_c = weather.get_object_member('item').get_object_member('condition');
-            let forecast = weather.get_object_member('item').get_array_member('forecast').get_elements();
+            let forecast = weather.get_object_member('item').get_object_member('forecast');
 
             /* TODO won't work with the new URL
             // Fixes wrong woeid if necessary
@@ -603,7 +603,8 @@ WeatherMenuButton.prototype = {
             let date_string = [_('Today'), _('Tomorrow')];
             for (let i = 0; i <= 1; i++) {
                 let forecastUi = this._forecast[i];
-                let forecastData = forecast[i].get_object();
+
+                let forecastData = weathers[i].get_object().get_object_member('item').get_object_member('forecast');
 
                 let code = forecastData.get_string_member('code');
                 let t_low = forecastData.get_string_member('low');


### PR DESCRIPTION
Hi, 
I may find something wrong, but I'm not sure. Because I nearly can not find any information in the website....
When I used the extension first time, it works well. And I like it. But when I finished my holiday and back to school, I found it can not work anymore. 
I'm in China. So you know, I thought the reason is the GFW block the Yahoo!'s weather service. BTW, I can browse Yahoo!'s weather website. So I was confused and folk the code.
Then I noticed that the URL you used to request the data is(as my test configuration):

http://query.yahooapis.com/v1/public/yql?format=json&q=select link,location,wind,atmosphere,units,item.condition,item.forecast from weather.forecast where location="2459114" and u="c";

I tried this URL in my chromium, and it responsed some data:

{"query":{"count":0,"created":"2012-03-06T06:07:53Z","lang":"en-US","results":null}}

You see, the results is null.
Then I find that YQL's example uses "woeid" rather than "location".
so I correct URL to

http://query.yahooapis.com/v1/public/yql?format=json&q=select link,location,wind,atmosphere,units,item.condition,item.forecast from weather.forecast where woeid="2459114" and u="c";

This URL is just change your URL's "location" to "woeid". And it returns useful data. 
I don't know why. Maybe Yahoo! changed its API. I'm not sure. 
But I'm sure that the code works well in my computer.

Hope you can accept the code. ^_^
