### PR TITLE
Updated URL to match actively maintained repository

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,4 +1,4 @@
-extensionurl = https://github.com/ecyrbe/gnome-shell-extension-weather
+extensionurl = https://github.com/simon04/gnome-shell-extension-weather
 
 # Change these to modify how installation is performed
 topextensiondir = $(datadir)/gnome-shell/extensions

--- a/src/extension.js
+++ b/src/extension.js
@@ -171,14 +171,14 @@ WeatherMenuButton.prototype = {
         switch (this._position_in_panel) {
             case WeatherPosition.LEFT:
                 children = Main.panel._leftBox.get_children();
-                Main.panel._leftBox.insert_actor (this.actor, children.length-1);
+                Main.panel._leftBox.insert_child_at_index(this.actor, children.length-1);
                 break;
             case WeatherPosition.CENTER:
                 Main.panel._centerBox.add(this.actor, { y_fill: true });
                 break;
             case WeatherPosition.RIGHT:
                 children = Main.panel._rightBox.get_children();
-                Main.panel._rightBox.insert_actor(this.actor, children.length-1);
+                Main.panel._rightBox.insert_child_at_index(this.actor, children.length-1);
                 break;
         }
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -29,6 +29,7 @@
  */
 
 const Cairo = imports.cairo;
+const Clutter = imports.gi.Clutter;
 const Gettext = imports.gettext.domain('gnome-shell-extension-weather');
 const Gio = imports.gi.Gio;
 const Gtk = imports.gi.Gtk;
@@ -143,7 +144,7 @@ WeatherMenuButton.prototype = {
         this._weatherIcon = new St.Icon({
             icon_type: this._icon_type,
             icon_name: 'view-refresh-symbolic',
-            style_class: 'system-status-icon weather-icon' + (Main.panel.actor.get_direction() == St.TextDirection.RTL ? '-rtl' : '')
+            style_class: 'system-status-icon weather-icon' + (Main.panel.actor.get_text_direction() == Clutter.TextDirection.RTL ? '-rtl' : '')
         });
 
         // Label
@@ -151,7 +152,7 @@ WeatherMenuButton.prototype = {
 
         // Panel menu item - the current class
         let menuAlignment = 0.25;
-        if (St.Widget.get_default_direction() == St.TextDirection.RTL)
+        if (Clutter.get_default_text_direction() == Clutter.TextDirection.RTL)
             menuAlignment = 1.0 - menuAlignment;
         PanelMenu.Button.prototype._init.call(this, menuAlignment);
 

--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -2,7 +2,7 @@
 "uuid": "@uuid@",
 "name": "Weather indicator",
 "description": "Adds weather information menu",
-"shell-version": [ "3.1.90", "3.1.91", "3.1.92", "3.2", "3.3", "3.3.90", "3.3.92" ],
+"shell-version": [ "3.1.90", "3.1.91", "3.1.92", "3.2", "3.3", "3.3.90", "3.3.92", "3.4" ],
 "localedir": "@LOCALEDIR@",
 "url": "@url@"
 }

--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -2,7 +2,7 @@
 "uuid": "@uuid@",
 "name": "Weather indicator",
 "description": "Adds weather information menu",
-"shell-version": [ "3.1.90", "3.1.91", "3.1.92", "3.2", "3.3", "3.3.90" ],
+"shell-version": [ "3.1.90", "3.1.91", "3.1.92", "3.2", "3.3", "3.3.90", "3.3.92" ],
 "localedir": "@LOCALEDIR@",
 "url": "@url@"
 }

--- a/src/metadata.json.in
+++ b/src/metadata.json.in
@@ -2,7 +2,7 @@
 "uuid": "@uuid@",
 "name": "Weather indicator",
 "description": "Adds weather information menu",
-"shell-version": [ "3.1.90", "3.1.91", "3.1.92", "3.2", "3.3" ],
+"shell-version": [ "3.1.90", "3.1.91", "3.1.92", "3.2", "3.3", "3.3.90" ],
 "localedir": "@LOCALEDIR@",
 "url": "@url@"
 }


### PR DESCRIPTION
The extension URL pointed to ecyrbe's git repository which seems to be abandoned. Changed it to simon04/gnome-shell-extension-weather github URL.
