### PR TITLE
Add override for weather-details URL

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -50,6 +50,7 @@ const WEATHER_SETTINGS_SCHEMA = 'org.gnome.shell.extensions.weather';
 const WEATHER_UNIT_KEY = 'unit';
 const WEATHER_WIND_SPEED_UNIT_KEY = 'wind-speed-unit';
 const WEATHER_CITY_KEY = 'city';
+const WEATHER_URL_KEY = 'details-url';
 const WEATHER_WOEID_KEY = 'woeid';
 const WEATHER_TRANSLATE_CONDITION_KEY = 'translate-condition';
 const WEATHER_SHOW_SUNRISE_SUNSET_KEY = 'show-sunrise-sunset';
@@ -104,6 +105,7 @@ WeatherMenuButton.prototype = {
         this._units = this._settings.get_enum(WEATHER_UNIT_KEY);
         this._wind_speed_units = this._settings.get_enum(WEATHER_WIND_SPEED_UNIT_KEY);
         this._city  = this._settings.get_string(WEATHER_CITY_KEY);
+        this._url = this._settings.get_string(WEATHER_URL_KEY);
         this._woeid = this._settings.get_string(WEATHER_WOEID_KEY);
         this._translate_condition = this._settings.get_boolean(WEATHER_TRANSLATE_CONDITION_KEY);
         this._show_sunrise = this._settings.get_boolean(WEATHER_SHOW_SUNRISE_SUNSET_KEY);
@@ -118,6 +120,7 @@ WeatherMenuButton.prototype = {
             this._units = this._settings.get_enum(WEATHER_UNIT_KEY);
             this._wind_speed_units = this._settings.get_enum(WEATHER_WIND_SPEED_UNIT_KEY);
             this._city  = this._settings.get_string(WEATHER_CITY_KEY);
+            this._url = this._settings.get_string(WEATHER_URL_KEY);
             this._woeid = this._settings.get_string(WEATHER_WOEID_KEY);
             this._translate_condition = this._settings.get_boolean(WEATHER_TRANSLATE_CONDITION_KEY);
             this._show_sunrise = this._settings.get_boolean(WEATHER_SHOW_SUNRISE_SUNSET_KEY);
@@ -128,6 +131,7 @@ WeatherMenuButton.prototype = {
         this._settings.connect('changed::' + WEATHER_UNIT_KEY, load_settings_and_refresh_weather);
         this._settings.connect('changed::' + WEATHER_WIND_SPEED_UNIT_KEY, load_settings_and_refresh_weather);
         this._settings.connect('changed::' + WEATHER_CITY_KEY, load_settings_and_refresh_weather);
+        this._settings.connect('changed::' + WEATHER_URL_KEY, load_settings_and_refresh_weather);
         this._settings.connect('changed::' + WEATHER_WOEID_KEY, load_settings_and_refresh_weather);
         this._settings.connect('changed::' + WEATHER_TRANSLATE_CONDITION_KEY, load_settings_and_refresh_weather);
         this._settings.connect('changed::' + WEATHER_SHOW_COMMENT_IN_PANEL_KEY, load_settings_and_refresh_weather);
@@ -601,9 +605,15 @@ WeatherMenuButton.prototype = {
                 this._currentWeatherWind.text = '\u2013';
 
             this._currentWeatherLocation.label = location + '...';
+
             // make the location act like a button
             this._currentWeatherLocation.style_class = 'weather-current-location-link';
-            this._currentWeatherLocation.url = weather.get_string_member('link');
+            // Link button to weather-details url
+            let link = weather.get_string_member('link');
+            if (this._url != null && this._url.length > 0)
+                link = this._url;
+            this._currentWeatherLocation.url = link;
+
             if (this._show_sunrise) {
                 this._currentWeatherSunrise.text = sunrise;
                 this._currentWeatherSunset.text = sunset;

--- a/src/extension.js
+++ b/src/extension.js
@@ -50,7 +50,7 @@ const WEATHER_SETTINGS_SCHEMA = 'org.gnome.shell.extensions.weather';
 const WEATHER_UNIT_KEY = 'unit';
 const WEATHER_WIND_SPEED_UNIT_KEY = 'wind-speed-unit';
 const WEATHER_CITY_KEY = 'city';
-const WEATHER_URL_KEY = 'details-url';
+const WEATHER_DETAILS_URL_KEY = 'details-url';
 const WEATHER_WOEID_KEY = 'woeid';
 const WEATHER_TRANSLATE_CONDITION_KEY = 'translate-condition';
 const WEATHER_SHOW_SUNRISE_SUNSET_KEY = 'show-sunrise-sunset';
@@ -105,7 +105,7 @@ WeatherMenuButton.prototype = {
         this._units = this._settings.get_enum(WEATHER_UNIT_KEY);
         this._wind_speed_units = this._settings.get_enum(WEATHER_WIND_SPEED_UNIT_KEY);
         this._city  = this._settings.get_string(WEATHER_CITY_KEY);
-        this._url = this._settings.get_string(WEATHER_URL_KEY);
+        this._details_url = this._settings.get_string(WEATHER_DETAILS_URL_KEY);
         this._woeid = this._settings.get_string(WEATHER_WOEID_KEY);
         this._translate_condition = this._settings.get_boolean(WEATHER_TRANSLATE_CONDITION_KEY);
         this._show_sunrise = this._settings.get_boolean(WEATHER_SHOW_SUNRISE_SUNSET_KEY);
@@ -120,7 +120,7 @@ WeatherMenuButton.prototype = {
             this._units = this._settings.get_enum(WEATHER_UNIT_KEY);
             this._wind_speed_units = this._settings.get_enum(WEATHER_WIND_SPEED_UNIT_KEY);
             this._city  = this._settings.get_string(WEATHER_CITY_KEY);
-            this._url = this._settings.get_string(WEATHER_URL_KEY);
+            this._details_url = this._settings.get_string(WEATHER_DETAILS_URL_KEY);
             this._woeid = this._settings.get_string(WEATHER_WOEID_KEY);
             this._translate_condition = this._settings.get_boolean(WEATHER_TRANSLATE_CONDITION_KEY);
             this._show_sunrise = this._settings.get_boolean(WEATHER_SHOW_SUNRISE_SUNSET_KEY);
@@ -131,7 +131,7 @@ WeatherMenuButton.prototype = {
         this._settings.connect('changed::' + WEATHER_UNIT_KEY, load_settings_and_refresh_weather);
         this._settings.connect('changed::' + WEATHER_WIND_SPEED_UNIT_KEY, load_settings_and_refresh_weather);
         this._settings.connect('changed::' + WEATHER_CITY_KEY, load_settings_and_refresh_weather);
-        this._settings.connect('changed::' + WEATHER_URL_KEY, load_settings_and_refresh_weather);
+        this._settings.connect('changed::' + WEATHER_DETAILS_URL_KEY, load_settings_and_refresh_weather);
         this._settings.connect('changed::' + WEATHER_WOEID_KEY, load_settings_and_refresh_weather);
         this._settings.connect('changed::' + WEATHER_TRANSLATE_CONDITION_KEY, load_settings_and_refresh_weather);
         this._settings.connect('changed::' + WEATHER_SHOW_COMMENT_IN_PANEL_KEY, load_settings_and_refresh_weather);
@@ -610,8 +610,8 @@ WeatherMenuButton.prototype = {
             this._currentWeatherLocation.style_class = 'weather-current-location-link';
             // Link button to weather-details url
             let link = weather.get_string_member('link');
-            if (this._url != null && this._url.length > 0)
-                link = this._url;
+            if (this._details_url != null && this._details_url.length > 0)
+                link = this._details_url;
             this._currentWeatherLocation.url = link;
 
             if (this._show_sunrise) {

--- a/src/org.gnome.shell.extensions.weather.gschema.xml.in
+++ b/src/org.gnome.shell.extensions.weather.gschema.xml.in
@@ -70,5 +70,10 @@
       <_summary>Refresh interval in seconds</_summary>
       <_description>The interval in seconds to refresh the weather information.</_description>
     </key>
+    <key name="details-url" type="s">
+      <default>''</default>
+      <_summary>URL to load when clicking on location name</_summary>
+      <_description>Optionally, define the weather details URL to load when the city name is clicked. If not set, the default URL from Yahoo Weather is used.</_description>
+    </key>
   </schema>
 </schemalist>

--- a/weather-extension-configurator.py
+++ b/weather-extension-configurator.py
@@ -118,6 +118,8 @@ class WeatherConfigurator:
                 [(0, 'kph'), (1, 'mph'), (2, 'm/s'), (3, 'knots')])
         self.add_text('city', 'Override Location Label',
                 "Sometimes your WOEID location isn’t quite right (it’s the next major city around). This label is used to override the location displayed.")
+        self.add_text('details-url', 'Override details URL',
+                "If you wish to define a different weather service to load when clicking on the Location name, provide the URL here. If not set, the default provided by Yahoo will be used.")
         self.add_radio('position-in-panel', 'Position in Panel',
                 [(2, 'left'), (0, 'center'), (1, 'right')],
                 "The position of this GNOME Shell extension in the panel. (Requires restart of GNOME Shell.)")


### PR DESCRIPTION
I **HATE** the new Yahoo Weather webpage. (The one loaded when clicking on the city name.) I hated the old one, but I hate the new one enough to actually _do something about it_.

While I'm not crazy about all of the changes weather.com have made recently, I'd still much rather get my weather information from them.

So, in the spirit of the 'city' configuration setting, this changeset (based off of the gnome3.4 branch) adds an optional config 'details-url'. If set to a URL (static string, nothing fancy or generated... so the location needs to be embedded, and manually updated if it changes), then clicking on the city name in the weather popup will load the specified page instead of the Yahoo Weather awfulness. (As with 'city', blanking the 'details-url' config resets the link to Yahoo's default.)

I now have mine set to `http://www.weather.com/weather/today/10454`, and all is right with the world. :-)

(Note: This is my first foray into github's fork/pull-request universe — I've just submitted patches in the past. So please let me know if I've horked anything along the way, and I'll try to course-correct.)
